### PR TITLE
add: converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LIBLARY = libft.a
 
 MAIN = srcs/main
 MAIN_FILES = display tokenizer lexer parser parser_get_utils \
-			 parser_set_utils free debug
+			 parser_set_utils free converter debug
 BIN_FILES = env
 GNL_FILES = get_next_line get_next_line_utils
 # COMMANDS_FILES = cmd_echo

--- a/include/libft.h
+++ b/include/libft.h
@@ -6,7 +6,7 @@
 /*   By: eunhkim <eunhkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/04/06 01:06:36 by eunhkim           #+#    #+#             */
-/*   Updated: 2020/07/02 23:24:00 by eunhkim          ###   ########.fr       */
+/*   Updated: 2020/07/05 14:21:39 by eunhkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,8 @@ int								ft_isnum(t_llint c);
 int								ft_isprint(int c);
 int								ft_isset(int c, char *set);
 int								ft_atoi(char *str);
+char							*ft_realloc(char **ptr, char c);
+void							*ft_memcpy(void *dst, const void *src, size_t n);
 
 // bonus
 int								ft_len_doublestr(char **arr);
@@ -65,5 +67,6 @@ int								ft_isformat(char *str, char *format);
 char							*ft_strreverse(char *src);
 int								ft_free(char *str);
 int								ft_isright_quote(char *src);
+int								ft_isright_envbracket(char *src);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -12,6 +12,7 @@
 # define DEBUG_LEXER	0
 # define DEBUG_PARSER	0
 # define DEBUG_TABLE	0
+# define DEBUG_CONVERT	0
 
 # define TRUE	 		1
 # define FALSE	 		0
@@ -81,6 +82,11 @@ int				lexer(char **tokens);
 ** parser functions
 */
 t_table			*parser(char **tokens);
+
+/*
+** converter
+*/
+void			converter(t_table *table);
 
 /*
 ** bin/env functions

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -8,11 +8,12 @@ MAIN_FILES = ft_strchr ft_strlen ft_split ft_strdup ft_calloc \
 			 ft_memset ft_strcat ft_strcpy ft_strjoin ft_strnew \
 			 ft_strsub ft_putstr_fd ft_isspace ft_strcmp ft_strncmp \
 			 ft_isalpha ft_isascii ft_isnum ft_isprint ft_isset \
-			 ft_atoi
+			 ft_atoi ft_realloc ft_memcpy
 
 BONUS_FILES = ft_dup_doublestr ft_len_doublestr ft_free_doublestr \
 			  ft_realloc_doublestr ft_startswith ft_isformat ft_in \
-			  ft_isitem ft_strreverse ft_free ft_isright_quote
+			  ft_isitem ft_strreverse ft_free ft_isright_quote \
+			  ft_isright_envbracket
 
 TEST_FILE = test/ft_split_test.c
 

--- a/libft/srcs/ft_isright_envbracket.c
+++ b/libft/srcs/ft_isright_envbracket.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_isright_envbracket.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: eunhkim <eunhkim@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2020/06/30 18:40:52 by eunhkim           #+#    #+#             */
+/*   Updated: 2020/07/05 14:26:13 by eunhkim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+static void	handle_quote(int *quote, char c)
+{
+	if (!(*quote))
+		*quote = c;
+	else if (*quote == c)
+		*quote = 0;
+}
+
+int			ft_isright_envbracket(char *src)
+{
+	int		idx;
+	int		quote;
+
+	idx = -1;
+	quote = 0;
+	while (src[++idx])
+	{
+		if (ft_isset(src[idx], "\'\""))
+			handle_quote(&quote, src[idx]);
+		if (!(src[idx] == '$' && src[idx + 1] == '{' && quote != '\''))
+			continue;
+		idx += 2;
+		while (src[idx] && !ft_isset(src[idx], "{}"))
+			idx++;
+		if (!src[idx] || src[idx] == '{')
+			return (0);
+	}
+	return (1);
+}

--- a/libft/srcs/ft_isright_envbracket.c
+++ b/libft/srcs/ft_isright_envbracket.c
@@ -6,7 +6,7 @@
 /*   By: eunhkim <eunhkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/06/30 18:40:52 by eunhkim           #+#    #+#             */
-/*   Updated: 2020/07/05 14:26:13 by eunhkim          ###   ########.fr       */
+/*   Updated: 2020/07/05 14:52:01 by eunhkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,9 +34,9 @@ int			ft_isright_envbracket(char *src)
 		if (!(src[idx] == '$' && src[idx + 1] == '{' && quote != '\''))
 			continue;
 		idx += 2;
-		while (src[idx] && !ft_isset(src[idx], "{}"))
+		while (src[idx] && !ft_isset(src[idx], "{}\'\""))
 			idx++;
-		if (!src[idx] || src[idx] == '{')
+		if (!src[idx] || src[idx] != '}')
 			return (0);
 	}
 	return (1);

--- a/libft/srcs/ft_memcpy.c
+++ b/libft/srcs/ft_memcpy.c
@@ -1,25 +1,32 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_strlen.c                                        :+:      :+:    :+:   */
+/*   ft_memcpy.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: eunhkim <eunhkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2020/02/24 21:34:59 by eunhkim           #+#    #+#             */
-/*   Updated: 2020/07/04 22:07:52 by eunhkim          ###   ########.fr       */
+/*   Created: 2020/02/24 22:21:22 by eunhkim           #+#    #+#             */
+/*   Updated: 2020/04/06 00:29:54 by eunhkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-int		ft_strlen(const char *str)
+void	*ft_memcpy(void *dst, const void *src, size_t n)
 {
-	int		cnt;
+	t_uchar		*uc_dst;
+	t_uchar		*uc_src;
+	size_t		index;
 
-	if (!str)
+	if (!dst && !src)
 		return (0);
-	cnt = 0;
-	while (str[cnt] != '\0')
-		cnt++;
-	return (cnt);
+	uc_dst = (t_uchar *)dst;
+	uc_src = (t_uchar *)src;
+	index = 0;
+	while (index < n)
+	{
+		uc_dst[index] = uc_src[index];
+		index++;
+	}
+	return (dst);
 }

--- a/libft/srcs/ft_realloc.c
+++ b/libft/srcs/ft_realloc.c
@@ -1,0 +1,18 @@
+#include "libft.h"
+
+char	*ft_realloc(char **ptr, char c)
+{
+	char	*ret;
+	int		size;
+
+	if (!ptr)
+		return (0);
+	size = ft_strlen(*ptr);
+	if (!(ret = (char *)ft_calloc(sizeof(char), size + 2)))
+		return (0);
+	ft_memcpy(ret, *ptr, size);
+	ret[size] = c;
+	ft_free(*ptr);
+	*ptr = ret;
+	return (ret);
+}

--- a/srcs/converter.c
+++ b/srcs/converter.c
@@ -1,0 +1,103 @@
+#include "minishell.h"
+
+static void		convert_env(char **ret, char *str, int *i)
+{
+	char	*name;
+	char	*val;
+	bool	bracket;
+	int		j;
+	char	end;
+
+	j = *i + 1;
+	if (!str[j])
+		return ;
+	bracket = (str[j] == '{') ? TRUE : FALSE;
+	j += (bracket) ? 1 : 0;
+	end = (bracket) ? '}' : ' ';
+	name = 0;
+	while (str[j] && str[j] != end && !ft_isset(str[j], "\'\""))
+		ft_realloc(&name, str[j++]);
+	if (!str[j] || end == ' ')
+		j--;
+	val = get_env(name);
+	*i = 0;
+	while (val && val[*i])
+		ft_realloc(ret, val[(*i)++]);
+	ft_free(name);
+	*i = j;
+	return ;
+}
+
+static void		convert(char **src)
+{
+	int		i;
+	int		opened;
+	char	*str;
+	char	*ret;
+
+	i = 0;
+	opened = 0;
+	str = *src;
+	if (!(ret = (char *)ft_calloc(sizeof(char), 1)))
+		return ;
+	while (str[i])
+	{
+		if (!opened && ft_isset(str[i], "\'\""))
+			opened = str[i];
+		else if (opened && opened == str[i])
+			opened = 0;
+		else if (opened != '\'' && str[i] == '$' \
+			&& str[i + 1] && !ft_isset(str[i + 1], " \'\""))
+				convert_env(&ret, str, &i);
+		else
+			ft_realloc(&ret, str[i]);
+		i++;
+	}
+	free(str);
+	*src = ret;
+}
+
+static void		convert_job(t_job *job)
+{
+	int			i;
+	t_redir		*redir;
+
+	if (job->command.cmd)
+		convert(&job->command.cmd);
+	if (job->command.arg_list)
+	{
+		i = 0;
+		while (job->command.arg_list[i])
+			convert(&job->command.arg_list[i++]);
+	}
+	if (job->redir_list)
+	{
+		redir = job->redir_list;
+		while (redir)
+		{
+			if (redir->sign)
+				convert(&redir->sign);
+			if (redir->arg)
+				convert(&redir->arg);
+			redir = redir->next;
+		}
+	}
+	return ;
+}
+
+void			converter(t_table *table)
+{
+	t_job	*job;
+
+	while (table)
+	{
+		job = table->job_list;
+		while (job)
+		{
+			convert_job(job);
+			job = job->next;
+		}
+		table = table->next;
+	}
+	return ;
+}

--- a/srcs/lexer.c
+++ b/srcs/lexer.c
@@ -6,7 +6,7 @@
 /*   By: eunhkim <eunhkim@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/06/26 23:09:30 by eunhkim           #+#    #+#             */
-/*   Updated: 2020/07/04 14:53:19 by eunhkim          ###   ########.fr       */
+/*   Updated: 2020/07/05 14:21:45 by eunhkim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -93,6 +93,8 @@ static int	is_valid_token(char **tokens, t_lexer *lex)
     if (lex->type == DSEMI || lex->type == EMPER)
         return (FALSE);
 	if (lex->type == STRING && !ft_isright_quote(tokens[lex->idx]))
+		return (FALSE);
+	if (lex->type == STRING && !ft_isright_envbracket(tokens[lex->idx]))
 		return (FALSE);
 	if (ft_isset(lex->type, "GHLM"))
 		return (!token_in(tokens, lex, FRONT_REDIR));

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -4,13 +4,13 @@ static void		process_line(char *line)
 {
 	char		**tokens;
 	t_table		*table;
-	static int	count;
 
 	tokens = tokenizer(line);
-	if (!(lexer(tokens)))
+	if (!lexer(tokens) || !(table = parser(tokens)))
 		return ;
-	table = parser(tokens);
-	if (table && (DEBUG_ALL || DEBUG_TABLE))
+	if (DEBUG_ALL || DEBUG_CONVERT || !DEBUG_TABLE)
+		converter(table);
+	if (DEBUG_ALL || DEBUG_TABLE || DEBUG_CONVERT)
 		print_table(table);
 	// if (!(table = parser(tokens)))
 	// 	return ;


### PR DESCRIPTION
## Converter 
- quote를 제거하고 환경변수를 치환하는 converter를 구현 완료했습니다.
- 환경변수의 경우 다음과 같은 규칙(like bash)에 의해 처리됩니다.

>-  '$' 하나만 쓰인다면 '$'문자 그대로 출력됩니다.
>- 겹따옴표(")로 둘려싸였다면 치환됩니다.
>- 홑따옴표(')로 둘러싸였다면 치환되지 않습니다.
>- '$' 다음에 '{' 문자가 온다면 홑따옴표, 겹따옴표, 여는 괄호({)를 만나기 이전에 닫는 괄호(})를 만나야 합니다. 그렇지 않으면 오류이며, unexpected token error와는 다른 에러 메시지가 출력됩니다. 현재 메시지까지 다르게 구현해두지는 않았습니다.

## Debug
명령어 구현시 테이블이 잘못 생성된 것으로 의심되는 경우 디버그 기능을 활용하시면 됩니다. minishell.h에 정의된 DEBUG_CONVERT 를 1로 설정하시면 테이블 내부 구조를 확인하실 수 있습니다. 테이블이 잘못 들어온 경우 DEBUG_CONVERT를 0으로 설정하고 DEBUG_TABLE을 1로 설정하시면 convert 되기 전의 테이블을 확인하실 수 있습니다. convert 과정의 문제가 아니라 table이 잘못 만들어진 경우, tokenizer, lexer, parser 등의 이슈일텐데 다른 디버그 옵션에 대해서는 오프라인으로 설명드리겠습니다.