### PR TITLE
Feat/cmd pwd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ CFLAGS = -Wall -Wextra -Werror
 LIB_DIR = libft/
 LIBLARY = libft.a
 
-MAIN = test/execute_single_job_test
+MAIN = test/cmd_pwd_test
 MAIN_FILES = display tokenizer lexer parser parser_get_utils \
 			 parser_set_utils free converter debug execute
-BIN_FILES = env cmd_echo
+BIN_FILES = env cmd_echo cmd_pwd
 GNL_FILES = get_next_line get_next_line_utils
 
 MAIN_PATH = $(addsuffix .c, $(MAIN))

--- a/include/execute.h
+++ b/include/execute.h
@@ -2,6 +2,7 @@
 # define EXECUTE_H
 
 # define N_OPTION -2
+# define PWD_BUFFER_SIZE 300
 
 # define    OR          'O'
 # define    AND         'A'

--- a/include/execute.h
+++ b/include/execute.h
@@ -26,9 +26,10 @@ void	execute_table(t_table *table);
 void	execute_table_with_single_job(t_table *table);
 
 /*
-**	in commands directory
+**	in bin directory
 */
 
 void	cmd_echo(t_command *cmd_list);	
+void	cmd_pwd(t_command *command);
 
 # endif

--- a/srcs/bin/cmd_pwd.c
+++ b/srcs/bin/cmd_pwd.c
@@ -5,8 +5,7 @@
 /*                                                    +:+ +:+         +:+     */
 /*   By: iwoo <iwoo@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2020/07/05 19:12:37 by iwoo              #+#    #+#             */
-/*   Updated: 2020/07/05 22:23:06 by iwoo             ###   ########.fr       */
+/*   Created: 2020/07/05 19:12:37 by iwoo              #+#    #+#             */ /*   Updated: 2020/07/05 22:47:17 by iwoo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,13 +21,14 @@ void	cmd_pwd(t_command *command)
 		ft_putstr_fd("pwd can't get any arguments\n", 2);
 		exit(-1);
 	}
-	path = get_env("PWD");
+	path = getcwd(NULL, PWD_BUFFER_SIZE);
 	if (!path)
 	{
-		ft_putstr_fd("Failed to get path\n", 2);
+		ft_putstr_fd("Failed to get path, please check 'PWD_BUFFER_SIZE'\n", 2);
 		exit(-1);
 	}
 	ft_putstr_fd(path, 1);
 	ft_putstr_fd("\n", 1);
+	free(path);
 	exit(0);
 }

--- a/srcs/bin/cmd_pwd.c
+++ b/srcs/bin/cmd_pwd.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cmd_pwd.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: iwoo <iwoo@student.42seoul.kr>             +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2020/07/05 19:12:37 by iwoo              #+#    #+#             */
+/*   Updated: 2020/07/05 22:23:06 by iwoo             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include "execute.h"
+
+void	cmd_pwd(t_command *command)
+{
+	char *path;
+
+	if (command->arg_list)
+	{
+		ft_putstr_fd("pwd can't get any arguments\n", 2);
+		exit(-1);
+	}
+	path = get_env("PWD");
+	if (!path)
+	{
+		ft_putstr_fd("Failed to get path\n", 2);
+		exit(-1);
+	}
+	ft_putstr_fd(path, 1);
+	ft_putstr_fd("\n", 1);
+	exit(0);
+}

--- a/srcs/execute.c
+++ b/srcs/execute.c
@@ -6,7 +6,7 @@
 /*   By: iwoo <iwoo@student.42seoul.kr>             +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/07/05 17:03:18 by iwoo              #+#    #+#             */
-/*   Updated: 2020/07/05 19:09:40 by iwoo             ###   ########.fr       */
+/*   Updated: 2020/07/05 22:30:04 by iwoo             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,8 @@ void		execute_command(t_command *cmd_list)
 	//TODO: add commands
 	if (!ft_strcmp(cmd_list->cmd, "echo"))
 		cmd_echo(cmd_list);
+	if (!ft_strcmp(cmd_list->cmd, "pwd"))
+		cmd_pwd(cmd_list);
 }
 
 int			count_job(t_job *job)
@@ -60,8 +62,7 @@ int			count_job(t_job *job)
 
 	i = 0;
 	while (job)
-	{
-		i++;
+	{ i++;
 		job = job->next;
 	}
 	return (i);

--- a/test/cmd_pwd_test.c
+++ b/test/cmd_pwd_test.c
@@ -1,0 +1,51 @@
+#include "minishell.h"
+#include "execute.h"
+
+static void		process_line(char *line)
+{
+	char		**tokens;
+	t_table		*table;
+	t_table		*first_table;
+
+	tokens = tokenizer(line);
+	if (!lexer(tokens) || !(table = parser(tokens)))
+		return ;
+	if (DEBUG_ALL || DEBUG_CONVERT || !DEBUG_TABLE)
+		converter(table);
+	if (DEBUG_ALL || DEBUG_TABLE || DEBUG_CONVERT)
+		print_table(table);
+	if (!(table = parser(tokens)))
+	 	return ;
+	first_table = table;
+	while (table)
+	{
+	//	converter(table);
+		execute_table_with_single_job(table);
+		wait(NULL);
+		table = table->next;
+	}
+	ft_free_doublestr(tokens);
+	free_table(first_table);
+}
+
+int				main(int ac, char *av[], char **env)
+{
+	char	*line;
+
+	display_logo();
+	init_env(env);
+
+	(void)ac;
+	(void)av;
+	while (TRUE)
+	{
+		display_prompt();
+		line = 0;
+		if (!(get_next_line(1, &line)))
+			continue;
+		process_line(line);
+		free(line);
+	}
+	ft_free_doublestr(g_env);
+	return (0);
+}


### PR DESCRIPTION
- 처음에는 get_env 함수로 pwd를 구현하려고 했으나, 환경변수 PWD가 변경되면 잘못된 프롬프트 값이 나타난다는 문제점이 있었습니다.
- 결과적으로 getpwd 함수를 써서 pwd를 구현하여 해결했습니다.
- 참고1) getpwd 함수는 인자 두개를 받는데 첫번째 인자에 NULL을 넣을 경우, 두번째 인자로 받은 SIZE 만큼의 '\0' terminated char array pointer를 malloc하여 반환합니다.
- 참고2) getpwd 함수의 두번째 인자로 넣는 SIZE는 execute.h 파일에 PWD_BUFFER_SIZE 라는 이름으로 선언해뒀습니다.